### PR TITLE
feature - scale note alteration

### DIFF
--- a/app/constants/keys.ts
+++ b/app/constants/keys.ts
@@ -41,51 +41,70 @@ export const notes = [
 export type Notes = (typeof notes)[number]
 
 export const midiNoteMap: Record<string, number> = {
-	'a#/bb2': 46,
+	'a#2': 46,
+	bb2: 46,
 	b2: 47,
 	c3: 48,
-	'c#/db3': 49,
+	'c#3': 49,
+	db3: 49,
 	d3: 50,
-	'd#/eb3': 51,
+	'd#3': 51,
+	eb3: 51,
 	e3: 52,
 	f3: 53,
-	'f#/gb3': 54,
+	'f#3': 54,
+	gb3: 54,
 	g3: 55,
-	'g#/ab3': 56,
+	'g#3': 56,
+	ab3: 56,
 	a3: 57,
-	'a#/bb3': 58,
+	'a#3': 58,
+	bb3: 58,
 	b3: 59,
 	c4: 60,
-	'c#/db4': 61,
+	'c#4': 61,
+	db4: 61,
 	d4: 62,
-	'd#/eb4': 63,
+	'd#4': 63,
+	eb4: 63,
 	e4: 64,
 	f4: 65,
-	'f#/gb4': 66,
+	'f#4': 66,
+	gb4: 66,
 	g4: 67,
-	'g#/ab4': 68,
+	'g#4': 68,
+	ab4: 68,
 	a4: 69,
-	'a#/bb4': 70,
+	'a#4': 70,
+	bb4: 70,
 	b4: 71,
 	c5: 72,
-	'c#/db5': 73,
+	'c#5': 73,
+	db5: 73,
 	d5: 74,
-	'd#/eb5': 75,
+	'd#5': 75,
+	eb5: 75,
 	e5: 76,
 	f5: 77,
-	'f#/gb5': 78,
+	'f#5': 78,
+	gb5: 78,
 	g5: 79,
-	'g#/ab5': 80,
+	'g#5': 80,
+	ab5: 80,
 	a5: 81,
-	'a#/bb5': 82,
+	'a#5': 82,
+	bb5: 82,
 	b5: 83,
 	c6: 84,
-	'c#/db6': 85,
+	'c#6': 85,
+	db6: 85,
 	d6: 86,
-	'd#/eb6': 87,
+	'd#6': 87,
+	eb6: 87,
 	e6: 88,
 	f6: 89,
-	'f#/gb6': 90,
+	'f#6': 90,
+	gb6: 90,
 	g6: 91,
 }
 
@@ -252,7 +271,7 @@ export const keyLayout: Record<
 }
 
 export interface Fingering {
-	note: string
+	note: string[]
 	octave: number
 	keyIds: string[][]
 }
@@ -261,7 +280,7 @@ export interface Fingering {
 export const fingerings: Record<number, Fingering> = {
 	// 2nd octave
 	46: {
-		note: 'a#/bb',
+		note: ['a#', 'bb'],
 		octave: 2,
 		keyIds: [
 			[
@@ -277,7 +296,7 @@ export const fingerings: Record<number, Fingering> = {
 		],
 	},
 	47: {
-		note: 'b',
+		note: ['b'],
 		octave: 2,
 		keyIds: [
 			[
@@ -295,7 +314,7 @@ export const fingerings: Record<number, Fingering> = {
 
 	// 3rd octave - middle c
 	48: {
-		note: 'c',
+		note: ['c'],
 		octave: 3,
 		keyIds: [
 			[
@@ -310,7 +329,7 @@ export const fingerings: Record<number, Fingering> = {
 		],
 	},
 	49: {
-		note: 'c#/db',
+		note: ['c#', 'db'],
 		octave: 3,
 		keyIds: [
 			[
@@ -326,12 +345,12 @@ export const fingerings: Record<number, Fingering> = {
 		],
 	},
 	50: {
-		note: 'd',
+		note: ['d'],
 		octave: 3,
 		keyIds: [['b-main', 'c-main', 'g-main', 'f-main', 'e-main', 'd-main']],
 	},
 	51: {
-		note: 'd#/eb',
+		note: ['d#', 'eb'],
 		octave: 3,
 		keyIds: [
 			[
@@ -346,37 +365,37 @@ export const fingerings: Record<number, Fingering> = {
 		],
 	},
 	52: {
-		note: 'e',
+		note: ['e'],
 		octave: 3,
 		keyIds: [['b-main', 'c-main', 'g-main', 'f-main', 'e-main']],
 	},
 	53: {
-		note: 'f',
+		note: ['f'],
 		octave: 3,
 		keyIds: [['b-main', 'c-main', 'g-main', 'f-main']],
 	},
 	54: {
-		note: 'f#/gb',
+		note: ['f#', 'gb'],
 		octave: 3,
 		keyIds: [['b-main', 'c-main', 'g-main', 'e-main']],
 	},
 	55: {
-		note: 'g',
+		note: ['g'],
 		octave: 3,
 		keyIds: [['b-main', 'c-main', 'g-main']],
 	},
 	56: {
-		note: 'g#/ab',
+		note: ['g#', 'ab'],
 		octave: 3,
 		keyIds: [['b-main', 'c-main', 'g-main', 'g#/ab-pinky']],
 	},
 	57: {
-		note: 'a',
+		note: ['a'],
 		octave: 3,
 		keyIds: [['b-main', 'c-main']],
 	},
 	58: {
-		note: 'a#/bb',
+		note: ['a#', 'bb'],
 		octave: 3,
 		keyIds: [
 			['b-main', 'b-bis'],
@@ -386,31 +405,31 @@ export const fingerings: Record<number, Fingering> = {
 		],
 	},
 	59: {
-		note: 'b',
+		note: ['b'],
 		octave: 3,
 		keyIds: [['b-main']],
 	},
 
 	// 4th octave
 	60: {
-		note: 'c',
+		note: ['c'],
 		octave: 4,
 		keyIds: [['c-main'], ['b-main', 'c-side']],
 	},
 	61: {
-		note: 'c#/db',
+		note: ['c#', 'db'],
 		octave: 4,
 		keyIds: [['']],
 	},
 	62: {
-		note: 'd',
+		note: ['d'],
 		octave: 4,
 		keyIds: [
 			['b-main', 'c-main', 'g-main', 'f-main', 'e-main', 'd-main', 'octave'],
 		],
 	},
 	63: {
-		note: 'd#/eb',
+		note: ['d#', 'eb'],
 		octave: 4,
 		keyIds: [
 			[
@@ -426,37 +445,37 @@ export const fingerings: Record<number, Fingering> = {
 		],
 	},
 	64: {
-		note: 'e',
+		note: ['e'],
 		octave: 4,
 		keyIds: [['b-main', 'c-main', 'g-main', 'f-main', 'e-main', 'octave']],
 	},
 	65: {
-		note: 'f',
+		note: ['f'],
 		octave: 4,
 		keyIds: [['b-main', 'c-main', 'g-main', 'f-main', 'octave']],
 	},
 	66: {
-		note: 'f#/gb',
+		note: ['f#', 'gb'],
 		octave: 4,
 		keyIds: [['b-main', 'c-main', 'g-main', 'e-main', 'octave']],
 	},
 	67: {
-		note: 'g',
+		note: ['g'],
 		octave: 4,
 		keyIds: [['b-main', 'c-main', 'g-main', 'octave']],
 	},
 	68: {
-		note: 'g#/ab',
+		note: ['g#', 'ab'],
 		octave: 4,
 		keyIds: [['b-main', 'c-main', 'g-main', 'g#/ab-pinky', 'octave']],
 	},
 	69: {
-		note: 'a',
+		note: ['a'],
 		octave: 4,
 		keyIds: [['b-main', 'c-main', 'octave']],
 	},
 	70: {
-		note: 'a#/bb',
+		note: ['a#', 'bb'],
 		octave: 4,
 		keyIds: [
 			['b-main', 'b-bis', 'octave'],
@@ -466,14 +485,14 @@ export const fingerings: Record<number, Fingering> = {
 		],
 	},
 	71: {
-		note: 'b',
+		note: ['b'],
 		octave: 4,
 		keyIds: [['b-main', 'octave']],
 	},
 
 	// 5th octave
 	72: {
-		note: 'c',
+		note: ['c'],
 		octave: 5,
 		keyIds: [
 			['c-main', 'octave'],
@@ -481,22 +500,22 @@ export const fingerings: Record<number, Fingering> = {
 		],
 	},
 	73: {
-		note: 'c#/db',
+		note: ['c#', 'db'],
 		octave: 5,
 		keyIds: [['octave']],
 	},
 	74: {
-		note: 'd',
+		note: ['d'],
 		octave: 5,
 		keyIds: [['d-palm', 'octave']],
 	},
 	75: {
-		note: 'd#/eb',
+		note: ['d#', 'eb'],
 		octave: 5,
 		keyIds: [['d-palm', 'd#/eb-palm', 'octave']],
 	},
 	76: {
-		note: 'e',
+		note: ['e'],
 		octave: 5,
 		keyIds: [
 			['d-palm', 'd#/eb-palm', 'e-side', 'octave'],
@@ -504,7 +523,7 @@ export const fingerings: Record<number, Fingering> = {
 		],
 	},
 	77: {
-		note: 'f',
+		note: ['f'],
 		octave: 5,
 		keyIds: [
 			['d-palm', 'd#/eb-palm', 'f-palm', 'e-side', 'octave'],
@@ -512,22 +531,22 @@ export const fingerings: Record<number, Fingering> = {
 		],
 	},
 	78: {
-		note: 'f#/gb',
+		note: ['f#', 'gb'],
 		octave: 5,
 		keyIds: [['f-fork', 'c-main', 'octave']],
 	},
 	79: {
-		note: 'g',
+		note: ['g'],
 		octave: 5,
 		keyIds: [['f-fork', 'f-main', 'e-side', 'octave']],
 	},
 	80: {
-		note: 'g#/ab',
+		note: ['g#', 'ab'],
 		octave: 5,
 		keyIds: [['b-main', 'c-main', 'g-main', 'c-side', 'a#/bb-side', 'octave']],
 	},
 	81: {
-		note: 'a',
+		note: ['a'],
 		octave: 5,
 		keyIds: [['f-fork', 'c-main', 'octave']],
 	},

--- a/app/constants/keys.ts
+++ b/app/constants/keys.ts
@@ -296,7 +296,7 @@ export const fingerings: Record<number, Fingering> = {
 		],
 	},
 	47: {
-		note: ['b'],
+		note: ['b', 'cb'],
 		octave: 2,
 		keyIds: [
 			[
@@ -405,7 +405,7 @@ export const fingerings: Record<number, Fingering> = {
 		],
 	},
 	59: {
-		note: ['b'],
+		note: ['b', 'cb'],
 		octave: 3,
 		keyIds: [['b-main']],
 	},
@@ -485,7 +485,7 @@ export const fingerings: Record<number, Fingering> = {
 		],
 	},
 	71: {
-		note: ['b'],
+		note: ['b', 'cb'],
 		octave: 4,
 		keyIds: [['b-main', 'octave']],
 	},

--- a/app/constants/keys.ts
+++ b/app/constants/keys.ts
@@ -23,6 +23,23 @@ export const octaveShiftKeys: string[] = ['z', 'x']
 // default octave is 3
 export const octave = [1, 2, 3, 4, 5, 6, 7, 8]
 
+export const notes = [
+	'a',
+	'a#/bb',
+	'b',
+	'c',
+	'c#/db',
+	'd',
+	'd#/eb',
+	'e',
+	'f',
+	'f#/gb',
+	'g',
+	'g#/ab',
+] as const
+
+export type Notes = (typeof notes)[number]
+
 export const midiNoteMap: Record<string, number> = {
 	'a#/bb2': 46,
 	b2: 47,
@@ -70,25 +87,6 @@ export const midiNoteMap: Record<string, number> = {
 	f6: 89,
 	'f#/gb6': 90,
 	g6: 91,
-}
-
-export const keyMap: Record<string, { note: string }> = {
-	a: { note: 'c' },
-	w: { note: 'c#/db' },
-	s: { note: 'd' },
-	e: { note: 'd#/eb' },
-	d: { note: 'e' },
-	f: { note: 'f' },
-	t: { note: 'f#/gb' },
-	g: { note: 'g' },
-	y: { note: 'g#/ab' },
-	h: { note: 'a' },
-	u: { note: 'a#/bb' },
-	j: { note: 'b' },
-	k: { note: 'c' },
-	o: { note: 'c#/db' },
-	l: { note: 'd' },
-	p: { note: 'd#/eb' },
 }
 
 // todo: finish keyGroups for eventual keyboard saxophone key control

--- a/app/routes/_alto+/index.tsx
+++ b/app/routes/_alto+/index.tsx
@@ -71,8 +71,6 @@ export default function Index() {
 		return getScaleFingerings(scaleQuality, scaleNote)
 	}, [scaleNote, scaleQuality])
 
-	console.log(currentScaleFingerings)
-
 	const note = Object.keys(midiNoteMap).find(
 		(key: string) => midiNoteMap[key] === currentMidiNote,
 	)

--- a/app/routes/_alto+/index.tsx
+++ b/app/routes/_alto+/index.tsx
@@ -1,9 +1,4 @@
-import {
-	acceptedKeys,
-	fingerings,
-	keyMap,
-	midiNoteMap,
-} from '#app/constants/keys.js'
+import { acceptedKeys, fingerings, midiNoteMap } from '#app/constants/keys.js'
 import { type MetaFunction } from '@remix-run/node'
 import { Canvas, useThree } from '@react-three/fiber'
 import {
@@ -123,7 +118,6 @@ export default function Index() {
 	}, [
 		currentKeyLayout,
 		currentFingerings,
-		keyMap,
 		currentMidiNote,
 		dispatch,
 		selectedKey,

--- a/app/routes/_alto+/index.tsx
+++ b/app/routes/_alto+/index.tsx
@@ -56,7 +56,10 @@ export default function Index() {
 	const [selectedKey, setSelectedKey] = useState('')
 	const [scaleQuality, setScaleQuality] = useState<ScaleQuality>('major')
 	const [scaleOctave, setScaleOctave] = useState(2)
-	const [scaleNote, setScaleNote] = useState(48)
+	const [scaleNote, setScaleNote] = useState({
+		midiNote: 48,
+		noteName: 'c',
+	})
 	const currentKeyLayout = useMemo(() => {
 		return acceptedKeys.map((key, index) => ({
 			key,
@@ -67,6 +70,8 @@ export default function Index() {
 	const currentScaleFingerings = useMemo(() => {
 		return getScaleFingerings(scaleQuality, scaleNote)
 	}, [scaleNote, scaleQuality])
+
+	console.log(currentScaleFingerings)
 
 	const note = Object.keys(midiNoteMap).find(
 		(key: string) => midiNoteMap[key] === currentMidiNote,
@@ -171,12 +176,13 @@ export default function Index() {
 		const regex = /^[a-gA-G#bB]+$/
 		if (!regex.test(e.target.value)) return
 
-		const selectedNote = `${e.target.value.toLocaleLowerCase()}${scaleOctave}`
+		const lowercaseNote = e.target.value.toLocaleLowerCase()
+		const selectedNote = `${lowercaseNote}${scaleOctave}`
 
 		if (selectedNote in midiNoteMap) {
 			const midiNote = midiNoteMap[selectedNote] || 0
 
-			setScaleNote(midiNote)
+			setScaleNote({ midiNote: midiNote, noteName: lowercaseNote })
 			dispatch({ type: 'setCurrentMidiNote', payload: midiNote })
 		}
 	}

--- a/app/utils/scales.ts
+++ b/app/utils/scales.ts
@@ -1,4 +1,4 @@
-import { fingerings } from '../constants/keys'
+import { fingerings, notes } from '../constants/keys'
 
 export const scaleQualities = [
 	'major',
@@ -22,6 +22,37 @@ const scaleNotes: Record<ScaleQuality, number[]> = {
 	dominant: [0, 2, 2, 1, 2, 2, 1, 2],
 	// w h w h w h w h
 	diminished: [0, 2, 1, 2, 1, 2, 1, 2, 1],
+}
+
+const majorFlats = ['c', 'f', 'bb', 'eb', 'ab', 'db', 'gb']
+const majorSharps = ['g', 'd', 'a', 'e', 'b', 'f#', 'c#']
+const minorFlats = ['a', 'd', 'g', 'c', 'f', 'bb', 'eb']
+const minorSharps = ['e', 'b', 'f#', 'c#', 'g#', 'd#', 'a#']
+const dominantFlats = ['f', 'bb', 'eb', 'ab', 'db', 'gb', 'cb']
+const dominantSharps = ['c', 'g', 'd', 'a', 'e', 'b', 'f#']
+const diminishedFlats = ['d', 'g', 'c', 'f', 'bb', 'eb', 'ab']
+const diminishedSharps = ['a', 'e', 'b', 'f#', 'c#', 'g#', 'd#']
+
+const alteration = ['flat', 'sharp'] as const
+
+export type Alteration = (typeof alteration)[number]
+
+// based on
+const returnSharpOrFlat = (note: string, alteration: Alteration) => {
+	// make sure note has flat value
+	if (!note.includes('/')) return
+
+	// # is 0 and b is 1 in returned array
+	const splitNote = note.split('/')
+
+	switch (alteration) {
+		case 'sharp':
+			return splitNote[0]
+		case 'flat':
+			return splitNote[1]
+		default:
+			return
+	}
 }
 
 // returns array of fingerings dependent on scale quality and starting note

--- a/app/utils/scales.ts
+++ b/app/utils/scales.ts
@@ -103,7 +103,7 @@ export const getScaleFingerings = (
 		return {
 			midiNote: note,
 			...fingerings[note],
-			note: returnSharpOrFlat(fingerings[note].note, scaleAlteration),
+			note: returnSharpOrFlat(fingerings[note]!.note, scaleAlteration),
 		}
 	})
 }

--- a/app/utils/scales.ts
+++ b/app/utils/scales.ts
@@ -1,4 +1,4 @@
-import { fingerings, notes } from '../constants/keys'
+import { fingerings } from '../constants/keys'
 
 export const scaleQualities = [
 	'major',
@@ -28,58 +28,82 @@ const majorFlats = ['c', 'f', 'bb', 'eb', 'ab', 'db', 'gb']
 const majorSharps = ['g', 'd', 'a', 'e', 'b', 'f#', 'c#']
 const minorFlats = ['a', 'd', 'g', 'c', 'f', 'bb', 'eb']
 const minorSharps = ['e', 'b', 'f#', 'c#', 'g#', 'd#', 'a#']
-const dominantFlats = ['f', 'bb', 'eb', 'ab', 'db', 'gb', 'cb']
-const dominantSharps = ['c', 'g', 'd', 'a', 'e', 'b', 'f#']
+const dominantFlats = ['c', 'f', 'bb', 'eb', 'ab', 'db', 'gb']
+const dominantSharps = ['g', 'd', 'a', 'e', 'b', 'f#']
 const diminishedFlats = ['d', 'g', 'c', 'f', 'bb', 'eb', 'ab']
 const diminishedSharps = ['a', 'e', 'b', 'f#', 'c#', 'g#', 'd#']
 
-const alteration = ['flat', 'sharp'] as const
+const alteration = ['flat', 'natural', 'sharp', 'none'] as const
 
 export type Alteration = (typeof alteration)[number]
 
-// based on
-const returnSharpOrFlat = (note: string, alteration: Alteration) => {
-	// make sure note has flat value
-	if (!note.includes('/')) return
+const returnSharpOrFlat = (note: string[], alteration: Alteration) => {
+	if (note.length > 1) {
+		// # is 0 and b is 1 in returned array
+		switch (alteration) {
+			case 'sharp':
+				return note[0]
+			case 'flat':
+				return note[1]
+			default:
+				return note.join('/')
+		}
+	} else {
+		return note
+	}
+}
 
-	// # is 0 and b is 1 in returned array
-	const splitNote = note.split('/')
-
-	switch (alteration) {
-		case 'sharp':
-			return splitNote[0]
-		case 'flat':
-			return splitNote[1]
+const getScaleAlteration = (quality: ScaleQuality, note: string) => {
+	switch (quality) {
+		case 'major':
+			if (majorFlats.includes(note)) return 'flat'
+			if (majorSharps.includes(note)) return 'sharp'
+		case 'minor':
+			if (minorFlats.includes(note)) return 'flat'
+			if (minorSharps.includes(note)) return 'sharp'
+		case 'dominant':
+			if (dominantFlats.includes(note)) return 'flat'
+			if (dominantSharps.includes(note)) return 'sharp'
+		case 'diminished':
+			if (diminishedFlats.includes(note)) return 'flat'
+			if (diminishedSharps.includes(note)) return 'sharp'
 		default:
-			return
+			return 'none'
 	}
 }
 
 // returns array of fingerings dependent on scale quality and starting note
 export const getScaleFingerings = (
 	quality: ScaleQuality,
-	startingNote: number,
+	startingNote: {
+		midiNote: number
+		noteName: string
+	},
 ) => {
+	const { midiNote, noteName } = startingNote
 	const scaleArr: number[] = []
 	scaleNotes[quality].reduce((prev: number, curr: number) => {
 		const nextValue = prev + curr
 		scaleArr.push(nextValue)
 		return nextValue
-	}, startingNote)
+	}, midiNote)
 
 	return scaleArr.map(note => {
 		if (!fingerings[note]) {
 			return {
 				midiNote: note,
-				note: 'unknown',
+				note: ['unknown'],
 				octave: 0,
 				keyIds: [],
 			}
 		}
 
+		const scaleAlteration = getScaleAlteration(quality, noteName)
+
 		return {
 			midiNote: note,
 			...fingerings[note],
+			note: returnSharpOrFlat(fingerings[note].note, scaleAlteration),
 		}
 	})
 }


### PR DESCRIPTION
## goal
- add functionality to render either sharp or flat value for notes in a scale
- implement basic working model of scale selection with according note alteration
## notes
- removed `keymap` (was unused)
- created helper function to return proper alteration
- updated `midinotemap` to include separate values per alteration
- built functionality for getting scale alterations (sharps or flats) and fingerings based on scale alts — `scales.ts`

